### PR TITLE
Fix broken country-files path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,12 @@ Add support for Xubuntu 22 for HamPC
 
 ### Removed
 
-flxmlrpc for now (Contacting Developer)
+- flxmlrpc for now (Contacting Developer)
 
 ### Fixed
 
-Fix Bullseye compatibility
-Prevent missing Python2 dependencies from getting installed on Xubuntu
+- Fix Bullseye compatibility
+- Prevent missing Python2 dependencies from getting installed on Xubuntu
 
 ## [3.0] - 2022-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Add support for Xubuntu 22 for HamPC
 
 - Fix Bullseye compatibility
 - Prevent missing Python2 dependencies from getting installed on Xubuntu
+- Broken path to country-file download
 
 ## [3.0] - 2022-03-29
 

--- a/tasks/download_country_files.yml
+++ b/tasks/download_country_files.yml
@@ -48,7 +48,7 @@
     shell: cp /home/{{ ham_user }}/hamradio/CTY_FILES/cty.dat /home/{{ ham_user }}/.local/share/WSJT-X
 
   - name: Determine latest version of BIGCTY on web
-    shell: curl --silent "https://www.country-files.com/" | grep -Po "https://www.country-files.com/bigcty/download/2022/bigcty-[0-9]+.zip" | head -n 1 | grep -Po "[0-9]+"
+    shell: curl --silent "https://www.country-files.com/" | grep -Po "https://www.country-files.com/bigcty/download/2022/bigcty-[0-9]+.zip" | head -n 1 | grep -Po "\-[0-9]+" | grep -Po "[0-9]+"
     args:
       warn: no
     register: bigcty_version


### PR DESCRIPTION
# bugfix/countryfilespath

## Where

On Ubuntu 22.04 local install build-from-source

## What

Both `2022` and the full date string (something like `20220812`) would be returned from the grep. This caused the next task to try to download the country-files for `2022`. I added an intermediate grep to be sure to grab only the complete date string.
