### PR TITLE
[Feature] - Add localhost install support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Desktop Launcher for NOAA-APT
 Add support for Xubuntu 22 for HamPC
+- Support to install from ansible playbook on the localhost with an existing user `hampc`
 
 ### Changed
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -24,6 +24,8 @@ inventory      = hosts
 #remote_port    = 22
 #module_lang    = C
 
+is_local_install = False
+
 # plays will gather facts by default, which contain information about
 # the remote system.
 #

--- a/hosts_ubuntu_local
+++ b/hosts_ubuntu_local
@@ -1,0 +1,12 @@
+#
+# Copyright 2020 - 2021, Dave Slotter (W3DJS). All rights reserved.
+#
+
+[all]
+127.0.0.1 ansible_user=hampi
+
+[all:vars]
+ansible_user=hampi
+ansible_password=hampi
+ansible_port=9022
+is_local_install=True

--- a/run_HamPi_playbook_ubuntu_local
+++ b/run_HamPi_playbook_ubuntu_local
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 - 2021, Dave Slotter (W3DJS). All rights reserved.
+#
+
+echo -n "Ansible Playbook Run started at: "
+start_time=`date`
+echo $start_time
+# Compute the seconds since epoch for start date
+t1=`date --date="$start_time" +%s`
+
+curdate=`date +%Y-%m-%d`
+
+echo "ansible-playbook -i hosts tasks/main.yml"
+ansible-playbook -u hampc -i hosts_ubuntu_local --connection=local ./tasks/main.yml | tee --append ansible-output_${curdate}.txt
+notify_via_email.py "Ansible has finished (HamPi)."
+
+# Compute the seconds since epoch for end date
+end_time=`date`
+t2=`date --date="$end_time" +%s`
+
+let diff_time=$t2-$t1
+printf "Total time for running Ansible Playbook: %02d:%02d:%02d\n" $((diff_time/3600)) $((diff_time%3600/60)) $((diff_time%60)) | tee --append ansible-output_${curdate}.txt

--- a/tasks/configuration_tasks.yml
+++ b/tasks/configuration_tasks.yml
@@ -30,7 +30,7 @@
   - name: Change hostname to hampc (for current session)
     become: yes
     command: hostname -b hampc
-    when: is_pc|bool
+    when: is_pc|bool and not is_local_install|bool
 
   - name: Change hostname to hampi (permanently)
     become: yes
@@ -44,7 +44,7 @@
     copy:
       src: "{{ playbook_dir }}/../files/etc/hostname_hampc"
       dest: "/etc/hostname"
-    when: is_pc|bool
+    when: is_pc|bool and not is_local_install|bool
 
   - name: Change hostname to hampi (for hosts file)
     become: yes
@@ -58,7 +58,7 @@
     copy:
       src: "{{ playbook_dir }}/../files/etc/hosts_hampc"
       dest: "/etc/hosts"
-    when: is_pc|bool
+    when: is_pc|bool and not is_local_install|bool
 
   - name: Store a basic version file in public location
     become: yes
@@ -207,7 +207,7 @@
     copy:
       src: "{{ playbook_dir }}/../files/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml"
       dest: "/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml"
-    when: ansible_distribution == "Ubuntu" and ansible_os_family == "Debian" and (ansible_architecture == "x86_64" or ansible_architecture == "amd64")
+    when: ansible_distribution == "Ubuntu" and ansible_os_family == "Debian" and (ansible_architecture == "x86_64" or ansible_architecture == "amd64") and not is_local_install|bool
 
   - name: Create /home/{{ ham_user }}/.config/pcmanfm/LXDE-pi directory
     file:


### PR DESCRIPTION
I wanted the ability to install locally onto my existing install of Ubuntu 22.04...

There were/are some bumps in the road still (a few apps still don't install correctly mostly due to the change to 22.04).

As for this PR, I added a new run script and ansible inventory that allow me to install to the local machine. I run `sudo ./run_HamPi_playbook_ubuntu_local` to execute this locally.