### PR TITLE
FreeDV: Disable LPCNet on 32-bit ARM.

### DIFF
--- a/tasks/install_freedv.yml
+++ b/tasks/install_freedv.yml
@@ -90,8 +90,15 @@
     register: result
     until: result.failed == false
 
-  - name: Build freedv-gui Binaries
+  - name: Build freedv-gui Binaries (not 32-bit ARM)
+    when: ansible_architecture != "armhf" and ansible_architecture != "armv7l"
     command: ./build_linux.sh pulseaudio
+    args:
+      chdir: /home/{{ ham_user }}/hamradio/freedv-gui
+
+  - name: Build freedv-gui Binaries (32-bit ARM)
+    when: ansible_architecture == "armhf" or ansible_architecture == "armv7l"
+    command: LPCNET_DISABLE=1 ./build_linux.sh pulseaudio
     args:
       chdir: /home/{{ ham_user }}/hamradio/freedv-gui
 
@@ -138,23 +145,28 @@
     delay: 30
     register: result
     until: result.failed == false
+    when: ansible_architecture != "armhf" and ansible_architecture != "armv7l"
 
   - name: Create directory LPCNet/build
+    when: ansible_architecture != "armhf" and ansible_architecture != "armv7l"
     file:
       path: /home/{{ ham_user }}/hamradio/LPCNet/build
       state: directory
 
   - name: Build LPCNet CMakeFiles
+    when: ansible_architecture != "armhf" and ansible_architecture != "armv7l"
     command: cmake ..
     args:
       chdir: /home/{{ ham_user }}/hamradio/LPCNet/build
 
   - name: Build LPCNet
+    when: ansible_architecture != "armhf" and ansible_architecture != "armv7l"
     command: make
     args:
       chdir: /home/{{ ham_user }}/hamradio/LPCNet/build
 
   - name: Install LPCNet
+    when: ansible_architecture != "armhf" and ansible_architecture != "armv7l"
     become: yes
     command: make install
     args:
@@ -174,8 +186,15 @@
       path: /home/{{ ham_user }}/hamradio/codec2/build
       state: directory
 
-  - name: Build Codec2 CMakeFiles
+  - name: Build Codec2 CMakeFiles (not 32-bit ARM)
+    when: ansible_architecture != "armhf" and ansible_architecture != "armv7l"
     command: cmake -Wno-dev -DLPCNET_BUILD_DIR=/home/{{ ham_user }}/hamradio/LPCNet/build ..
+    args:
+      chdir: /home/{{ ham_user }}/hamradio/codec2/build
+
+  - name: Build Codec2 CMakeFiles (32-bit ARM)
+    when: ansible_architecture == "armhf" or ansible_architecture == "armv7l"
+    command: cmake -Wno-dev ..
     args:
       chdir: /home/{{ ham_user }}/hamradio/codec2/build
 
@@ -195,6 +214,7 @@
     command: ldconfig
 
   - name: Remove LPCNet build directory
+    when: ansible_architecture != "armhf" and ansible_architecture != "armv7l"
     file:
       path: /home/{{ ham_user }}/hamradio/LPCNet
       state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,7 +130,7 @@
 ### DJS Website gone - import_playbook: install_twclock.yml
 ### DJS Website gone - import_playbook: install_twhamqth.yml
 - import_playbook: install_wxtoimg.yml
-### Build broken under Bookworm - import_playbook: install_freedv.yml
+- import_playbook: install_freedv.yml
 ### Build broken under Bookworm - import_playbook: install_dump1090.yml
 - import_playbook: install_acarsdec.yml
 - import_playbook: install_voacapl.yml


### PR DESCRIPTION
This PR disables LPCNet for 32-bit builds to allow FreeDV to build on 32-bit Bookworm. 64-bit builds *should* still include it, though (if I'm understanding Ansible correctly, anyway; I'm having difficulty testing this change my own Pi due to it complaining about not being able to find the latest version of CMake on GitHub).

For context: FreeDV traditionally required LPCNet to build/execute even if the machine was too slow to be able to use the FreeDV 2020 modes. As 2020/2020B modes may be deprecated soon, it was decided to perform only minimal maintenance on the FreeDV version of the LPCNet library (meaning that changes to allow it to build on the 32-bit ARM version of Bookworm are probably not coming any time soon) and uncouple the main FreeDV application from LPCNet. 